### PR TITLE
Update email address and source link in Code of Conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -55,8 +55,10 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
+reported by contacting the project team at
+[safespace@codeforlansing.org](mailto:safespace@codeforlansing.org).
+
+All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
@@ -67,10 +69,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-
-[homepage]: https://www.contributor-covenant.org
+This Code of Conduct is adapted from
+[Contributor Covenant Version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq


### PR DESCRIPTION
- Provide email address where CoC violations may be reported
- Shorten link to Code of Conduct source page